### PR TITLE
Document LOAD_PCT expected values

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -38,7 +38,7 @@
   ]},
 { "hdr": "7E0", "rax": "7E8", "cmd": {"01": "04"}, "freq": 0.25,
   "signals": [
-    {"id": "LOAD_PCT", "path": "Engine.Generic", "fmt": { "len": 8, "max": 100, "mul": 100, "div": 255, "unit": "percent" }, "name": "Calculated engine load", "description": "Represents the amount of work the engine is doing."}
+    {"id": "LOAD_PCT", "path": "Engine.Generic", "fmt": { "len": 8, "max": 100, "mul": 100, "div": 255, "unit": "percent" }, "name": "Calculated engine load", "description": "Represents the amount of work the engine is doing. Expected to reach 100% at wide open throttle/wide open pedal at any altitude, temperature or rpm for both naturally aspirated and boosted engines. If engine load is limited for powertrain protection e.g. engine/turbocharger protection, this value may not reach 100%. For hybrid vehicles, indicates the torque produced only by the internal combustion engine, not the torque being delivered by the entire powertrain. For electric vehicles, the meaning of this parameter is undefined."}
   ]},
 { "hdr": "7E0", "rax": "7E8", "cmd": {"01": "05"}, "freq": 0.5,
   "signals": [


### PR DESCRIPTION
Specifically for EVs, where the value on the Taycan seems to be 100% at all times.